### PR TITLE
Fix heading typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Answering `Yes` will release the message.
 3. Run `setup.exe`
 4. Restart Outlook to load the Add-in
 
-## Troublehooting
+## Troubleshooting
 
 1. Open Outlook
 2. Ensure there is no yellow warning under `Slow and Disabled COM Add-ins`. You can re-enable it there.


### PR DESCRIPTION
## Summary
- correct "Troublehooting" typo in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_683dbb12eb54832abdc56086aae356f3