### PR TITLE
Fix ItemSend to use passed MailItem

### DIFF
--- a/Walled Garden Outlook AddIn/OutlookAddIn/ThisAddIn.cs
+++ b/Walled Garden Outlook AddIn/OutlookAddIn/ThisAddIn.cs
@@ -21,10 +21,16 @@ namespace OutlookAddIn
 
         void OutlookApplication_ItemSend(object Item, ref bool Cancel)
         {
-            String Domain = "@" + this.mailItem.SendUsingAccount.SmtpAddress.Split('@')[1];
+            Outlook.MailItem mailItem = Item as Outlook.MailItem;
+            if (mailItem == null)
+            {
+                return;
+            }
+
+            String Domain = "@" + mailItem.SendUsingAccount.SmtpAddress.Split('@')[1];
             String Outsiders = "";
 
-            foreach (Recipient recipient in this.mailItem.Recipients)
+            foreach (Recipient recipient in mailItem.Recipients)
             {
                 if (recipient.Address.Contains("@") && !recipient.Address.EndsWith(Domain))
                 {


### PR DESCRIPTION
## Summary
- fix ItemSend handler to inspect the sent `MailItem`

## Testing
- `ls -R | grep -i test`

------
https://chatgpt.com/codex/tasks/task_b_683db3a15978832aa776fa01ea3191e2